### PR TITLE
 feat  : 배송담당자  로테이션 형태 배정 기능 구현

### DIFF
--- a/gateway/src/main/java/com/_hateam/config/SecurityConfig.java
+++ b/gateway/src/main/java/com/_hateam/config/SecurityConfig.java
@@ -93,6 +93,7 @@ public class SecurityConfig {
 
                 .authorizeExchange(exchange -> exchange
                         .pathMatchers("/api/auth/**").permitAll()
+                        .pathMatchers("/api/users/signup").permitAll()
                         .pathMatchers(HttpMethod.PUT,"/api/users/roles/**").hasAuthority("ADMIN")
                         .anyExchange().authenticated()
                 )

--- a/gateway/src/main/java/com/_hateam/filter/JwtAuthenticationFilter.java
+++ b/gateway/src/main/java/com/_hateam/filter/JwtAuthenticationFilter.java
@@ -28,15 +28,15 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     @Override
     public int getOrder() {
         return Ordered.HIGHEST_PRECEDENCE; // 가장 높은 우선순위 설정
-//        return Ordered.LOWEST_PRECEDENCE; // 또는 다른 적절한 값
+//        return Ordered.LOWEST_PRECEDENCE; // 또는 다른 적절한 값it st
     }
     @Value("${service.jwt.secret-key}")
     private String secretKey;
 
     // JWT 토큰 검증을 제외할 경로 목록
     private static final List<String> EXCLUDE_PATHS = List.of(
-            "/api/auth/signIn"
-    //      "/api/users/**"
+            "/api/auth/signIn",
+          "/api/users/signup"
               // 필요에 따라 추가/제거 가능
     );
 

--- a/user/user/src/main/java/com/_hateam/user/application/service/AdminDataService.java
+++ b/user/user/src/main/java/com/_hateam/user/application/service/AdminDataService.java
@@ -1,0 +1,99 @@
+package com._hateam.user.application.service;
+
+
+import com._hateam.user.application.dto.DeliverUserCreateReqDto;
+import com._hateam.user.domain.enums.DeliverType;
+import com._hateam.user.domain.enums.Status;
+import com._hateam.user.domain.enums.UserRole;
+import com._hateam.user.domain.model.User;
+import com._hateam.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDataService {
+
+    private final UserRepository userRepository;
+    private final DeliverUserService deliverUserService; // 위 createDeliverUser()를 사용하는 Service
+
+    @Transactional
+    public void bulkInsertDummyData() {
+        // 1) 허브 배송담당자 10명
+        for (int i = 1; i <= 10; i++) {
+            // 1-A) User 생성
+            User user = User.builder()
+                    .username("hub_deliver_" + i)  // 예: "hub_deliver_1"
+                    .nickname("허브배달원" + i)
+                    .password("TEST_PASSWORD") // 실제론 암호화 필요
+                    .slackId("SLACK_HUB_" + i)
+                    .userRoles(UserRole.DELIVERY)  // 혹은 HUB 등등, 정책에 맞게
+                    .isDeliver(true)
+                    .build();
+            userRepository.save(user);
+
+            // 1-B) DeliverUserCreateReqDto 준비
+            DeliverUserCreateReqDto dto = DeliverUserCreateReqDto.builder()
+                    .userId(user.getUserId())   // 위에서 save된 user의 PK(Long)
+                    .hubId(null)               // 허브배송 → hubId null
+                    .slackId(user.getSlackId())
+                    .name(user.getNickname())
+                    .deliverType(DeliverType.DELIVER_HUB)
+                    .contactNumber("010-1111-11" + String.format("%02d", i))
+                    .status(Status.ACTIVE)
+                    .build();
+
+            // 1-C) createDeliverUser(...) 호출 → rotationOrder는 자동 +1
+            deliverUserService.createDeliverUser(dto);
+        }
+
+        // 2) 업체 배송담당자 (예: 허브가 17개 있다고 가정)
+        //    각 허브마다 10명씩
+        for (int hubIndex = 1; hubIndex <= 17; hubIndex++) {
+            UUID hubUuid = UUID.randomUUID(); // 실제로는 특정 허브 UUID가 있을 수도 있음
+
+            for (int j = 1; j <= 10; j++) {
+                // 2-A) User 생성
+                User user = User.builder()
+                        .username("company_" + hubIndex + "_deliver_" + j) // 유니크 이름
+                        .nickname("업체배달원" + hubIndex + "-" + j)
+                        .password("TEST_PASSWORD")
+                        .slackId("SLACK_COMPANY_" + hubIndex + "_" + j)
+                        .userRoles(UserRole.DELIVERY)
+                        .isDeliver(true)
+                        .build();
+                userRepository.save(user);
+
+                // 2-B) DeliverUserCreateReqDto
+                DeliverUserCreateReqDto dto = DeliverUserCreateReqDto.builder()
+                        .userId(user.getUserId())
+                        .hubId(hubUuid)  // 업체배송 → hubId 있음
+                        .slackId(user.getSlackId())
+                        .name(user.getNickname())
+                        .deliverType(DeliverType.DELIVER_COMPANY)
+                        .contactNumber("010-2222-" + String.format("%04d", (hubIndex * 100 + j)))
+                        .status(Status.ACTIVE)
+                        .build();
+
+                // 2-C) 호출
+                deliverUserService.createDeliverUser(dto);
+            }
+        }
+    }
+
+    // 필요하다면, 전체 삭제 후 다시 삽입하는 메서드도 가능
+    @Transactional
+    public void resetAndInsertDummyData() {
+        // 만약 데이터 전부 지우고 싶다면...
+        // (주의: 실제 운영 DB에서 deleteAll()은 조심히 사용)
+        // userRepository.deleteAll();
+        // deliverUserRepository.deleteAll();
+        // 등등...
+
+        bulkInsertDummyData();
+    }
+
+}

--- a/user/user/src/main/java/com/_hateam/user/application/service/DeliverUserService.java
+++ b/user/user/src/main/java/com/_hateam/user/application/service/DeliverUserService.java
@@ -1,6 +1,7 @@
 package com._hateam.user.application.service;
 
 import com._hateam.user.application.dto.*;
+import com._hateam.user.domain.enums.DeliverType;
 import com._hateam.user.infrastructure.security.UserPrincipals;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,5 +35,11 @@ public interface DeliverUserService {
     List<FeignInHubDeliverResDto> getHubDeliver();
 
     FeignDeliverSlackIdResDto getDeliverSlackUserById(UUID deliverId);
+
+
+    UUID assignNextDeliverUser(DeliverType deliverType, UUID hubId);
+
+//    DeliverUserResponseDto createDeliverUser(DeliverUserCreateReqDto deliverUserCreateReqDto);
+
 
 }

--- a/user/user/src/main/java/com/_hateam/user/domain/enums/DeliverType.java
+++ b/user/user/src/main/java/com/_hateam/user/domain/enums/DeliverType.java
@@ -3,6 +3,6 @@ package com._hateam.user.domain.enums;
 public enum DeliverType {
 
     DELIVER_HUB,
-    DELIVER_COMPANY,
+    DELIVER_COMPANY
 
 }

--- a/user/user/src/main/java/com/_hateam/user/domain/model/DeliverAssignPointer.java
+++ b/user/user/src/main/java/com/_hateam/user/domain/model/DeliverAssignPointer.java
@@ -1,0 +1,34 @@
+package com._hateam.user.domain.model;
+
+import com._hateam.user.domain.enums.DeliverType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "deliver_assign_pointer",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"deliverType", "hubId"})
+        })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeliverAssignPointer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pointerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "deliverType")
+    private DeliverType deliverType;
+
+    @Column(name = "hubId")
+    private UUID hubId;  // 허브배송이면 null, 업체배송이면 실제 허브 UUID
+
+    // 마지막으로 배정된 rotationOrder
+    private Integer lastAssignedRotationOrder;
+}

--- a/user/user/src/main/java/com/_hateam/user/domain/repository/DeliverUserRepository.java
+++ b/user/user/src/main/java/com/_hateam/user/domain/repository/DeliverUserRepository.java
@@ -1,6 +1,7 @@
 package com._hateam.user.domain.repository;
 
 import com._hateam.user.domain.enums.DeliverType;
+import com._hateam.user.domain.enums.Status;
 import com._hateam.user.domain.model.DeliverUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,5 +29,16 @@ public interface DeliverUserRepository {
     Page<DeliverUser> findByNameContainingAndHubIdAndDeletedAtIsNull(String name, UUID hubId, Pageable pageable);
 
     List<DeliverUser> findByDeliverTypeAndDeletedAtIsNull(DeliverType deliverType);
+
+    // 1) HUB인 애들만 rotationOrder asc 로 전부 조회
+    List<DeliverUser> findByStatusAndDeliverTypeOrderByRotationOrderAsc(Status status, DeliverType deliverType);
+
+    // 2) COMPANY면서 특정 hubId인 애들만 rotationOrder asc 로 전부 조회
+    List<DeliverUser> findByStatusAndDeliverTypeAndHubIdOrderByRotationOrderAsc(
+            Status status, DeliverType deliverType, UUID hubId
+    );
+
+    // 추가: (deliverType, hubId)별로 rotationOrder 중 가장 큰 값 조회
+    Integer findMaxRotationOrder(DeliverType deliverType, UUID hubId);
 
 }

--- a/user/user/src/main/java/com/_hateam/user/infrastructure/repository/DeliverAssignPointerRepository.java
+++ b/user/user/src/main/java/com/_hateam/user/infrastructure/repository/DeliverAssignPointerRepository.java
@@ -1,0 +1,13 @@
+package com._hateam.user.infrastructure.repository;
+import com._hateam.user.domain.enums.DeliverType;
+import com._hateam.user.domain.model.DeliverAssignPointer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+public interface DeliverAssignPointerRepository extends JpaRepository<DeliverAssignPointer, Long> {
+
+    // deliverType + hubId 조합으로 Pointer 찾기
+    Optional<DeliverAssignPointer> findByDeliverTypeAndHubId(DeliverType deliverType, UUID hubId);
+
+}

--- a/user/user/src/main/java/com/_hateam/user/infrastructure/repository/DeliverUserRepositoryImpl.java
+++ b/user/user/src/main/java/com/_hateam/user/infrastructure/repository/DeliverUserRepositoryImpl.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
+import com._hateam.user.domain.enums.Status;
 @Repository
 @RequiredArgsConstructor
-public class DeliverUserRepositoryImpl implements DeliverUserRepository{
+public class DeliverUserRepositoryImpl implements DeliverUserRepository {
 
     private final JpaDeliverUserRepository jpaDeliverUserRepository;
 
@@ -57,6 +57,30 @@ public class DeliverUserRepositoryImpl implements DeliverUserRepository{
     public List<DeliverUser> findByDeliverTypeAndDeletedAtIsNull(DeliverType deliverType) {
         return jpaDeliverUserRepository.findByDeliverTypeAndDeletedAtIsNull(deliverType);
     }
+
+    @Override
+    public List<DeliverUser> findByStatusAndDeliverTypeOrderByRotationOrderAsc
+            (Status status, DeliverType deliverType) {
+        return jpaDeliverUserRepository.findByStatusAndDeliverTypeOrderByRotationOrderAsc
+                (status,deliverType);
+    }
+
+    @Override
+    public List<DeliverUser> findByStatusAndDeliverTypeAndHubIdOrderByRotationOrderAsc
+            (Status status, DeliverType deliverType, UUID hubId) {
+        return jpaDeliverUserRepository.findByStatusAndDeliverTypeAndHubIdOrderByRotationOrderAsc(
+                status, deliverType, hubId);
+    }
+ ///////////
+
+
+
+ // 추가: (deliverType, hubId)별로 rotationOrder 중 가장 큰 값 조회
+ @Override
+ public Integer findMaxRotationOrder(DeliverType deliverType, UUID hubId) {
+     return jpaDeliverUserRepository.findMaxRotationOrder(deliverType, hubId);
+ }
+
 
 
 

--- a/user/user/src/main/java/com/_hateam/user/infrastructure/repository/JpaDeliverUserRepository.java
+++ b/user/user/src/main/java/com/_hateam/user/infrastructure/repository/JpaDeliverUserRepository.java
@@ -7,6 +7,8 @@ import com._hateam.user.domain.model.DeliverUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -39,5 +41,32 @@ public interface JpaDeliverUserRepository  extends JpaRepository<DeliverUser, UU
     List<DeliverUser> findByDeliverTypeAndDeletedAtIsNull(DeliverType deliverType);
     //user도메인
 
+    // 1) HUB인 애들만 rotationOrder asc 로 전부 조회
+    List<DeliverUser> findByStatusAndDeliverTypeOrderByRotationOrderAsc(Status status, DeliverType deliverType);
+
+    // 2) COMPANY면서 특정 hubId인 애들만 rotationOrder asc 로 전부 조회
+    List<DeliverUser> findByStatusAndDeliverTypeAndHubIdOrderByRotationOrderAsc(
+            Status status, DeliverType deliverType, UUID hubId);
+
+//
+//    @Query("SELECT d FROM DeliverUser d WHERE d.deliverId = :deliverId")
+//    Optional<DeliverUser> findByDeliverId(@Param("deliverId") UUID deliverId);
+
+    // (deliverType, hubId)별 최대 rotationOrder 조회
+    @Query("""
+           SELECT MAX(d.rotationOrder) 
+           FROM DeliverUser d
+           WHERE d.deliverType = :deliverType
+             AND (
+                (:hubId IS NULL AND d.hubId IS NULL)
+                OR (:hubId IS NOT NULL AND d.hubId = :hubId)
+             )
+           """)
+    Integer findMaxRotationOrder(@Param("deliverType") DeliverType deliverType,
+                                 @Param("hubId") UUID hubId);
+
+//    // 예시) (deliverType, hubId) & status=ACTIVE 목록
+//    List<DeliverUser> findByStatusAndDeliverTypeOrderByRotationOrderAsc(Status status, DeliverType deliverType);
+//    List<DeliverUser> findByStatusAndDeliverTypeAndHubIdOrderByRotationOrderAsc(Status status, DeliverType deliverType, UUID hubId);
 
 }

--- a/user/user/src/main/java/com/_hateam/user/infrastructure/repository/JpaUserRepository.java
+++ b/user/user/src/main/java/com/_hateam/user/infrastructure/repository/JpaUserRepository.java
@@ -20,4 +20,8 @@ public interface JpaUserRepository extends JpaRepository<User,Long> {
 
     // UserRepository.java에 추가
     List<User> findAllByUserRolesAndDeletedAtIsNull(UserRole userRole);
+
+
+
+
 }

--- a/user/user/src/main/java/com/_hateam/user/presentation/controller/DeliverController.java
+++ b/user/user/src/main/java/com/_hateam/user/presentation/controller/DeliverController.java
@@ -87,6 +87,16 @@ public class DeliverController {
     }
 
 
+//    // 배송 담당자 단일 조회(권한별 분리)
+//    @GetMapping("/rotate")
+//    public ResponseEntity<?> getRotationDeliverUser(HttpServletRequest request) {
+//        String userId = request.getHeader("x-user-id");
+//        String userRole = request.getHeader("x-user-role");
+//
+//        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.success(deliverUserService.getDeliverUserById(deliverId, userId, userRole)));
+//    }
+
+
     @GetMapping("/delivery")//업체 소속 배달담당자 조회 Deliverer중 COM
     public ResponseEntity<?> getCompanyDeliver() {
 

--- a/user/user/src/main/java/com/_hateam/user/presentation/controller/DeliverUserController.java
+++ b/user/user/src/main/java/com/_hateam/user/presentation/controller/DeliverUserController.java
@@ -1,0 +1,52 @@
+package com._hateam.user.presentation.controller;
+
+import com._hateam.user.application.service.AdminDataService;
+import com._hateam.user.application.service.DeliverUserService;
+import com._hateam.user.domain.enums.DeliverType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/deliver-assign")
+public class DeliverUserController {
+
+    private final DeliverUserService deliverUserService;
+    private final AdminDataService adminDataService;
+    public DeliverUserController(DeliverUserService deliverUserService, AdminDataService adminDataService) {
+        this.deliverUserService = deliverUserService;
+        this.adminDataService = adminDataService;
+    }
+
+    /**
+     * 예시:
+     * [GET] /api/v1/deliver-assign?deliverType=HUB
+     * [GET] /api/v1/deliver-assign?deliverType=COMPANY&hubId={some-uuid}
+     */
+    @GetMapping
+    public UUID assignDeliverUser(
+            @RequestParam("deliverType") DeliverType deliverType,
+            @RequestParam(value = "hubId", required = false) UUID hubId
+    ) {
+        return deliverUserService.assignNextDeliverUser(deliverType, hubId);
+    }
+
+    // 예) 마스터 관리자만 호출 가능하다고 가정
+    @PostMapping("/init-dummy-data")
+    public ResponseEntity<?> initDummyData(
+//            @RequestHeader("x-user-role") String userRole)
+    ){
+//        if (!"ADMIN".equals(userRole)) {
+//            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+//                    .body("관리자 권한이 필요합니다.");
+//        }
+
+        // 더미 데이터 삽입
+        adminDataService.bulkInsertDummyData();
+
+        return ResponseEntity.ok("더미 배송담당자 180명 생성 완료");
+    }
+}


### PR DESCRIPTION
## 💡 이슈
- resolve # 55

## 🤩 개요
배송담당자 배정 기능 구현

## 🧑‍💻 작업 사항

- 더미데이터 180개(170개 업체배송담당자, 10개 허브배송담당자) 생성 임시구현
- 배송담당자 순번  배정기능 구현
## 📖 참고 사항
- 먼저 관리자계정 생성 후(현재는 모든권한가능) , 더미데이터 생성, 이후 순번배정요청시 작동
